### PR TITLE
breaking: no more releases on gh registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-registry=https://npm.pkg.github.com/
-access=public


### PR DESCRIPTION
Provides bad ergonomics for `npx`