### PR TITLE
feat: ignore duplicate pulls

### DIFF
--- a/actions/watch-material-ui/main.js
+++ b/actions/watch-material-ui/main.js
@@ -44,17 +44,21 @@ async function main() {
 
 		await git(`push origin -f ${branch}`);
 		const octokit = new github.GitHub(core.getInput("token"));
-		await octokit.pulls.create({
-			owner: github.context.repo.owner,
-			repo: github.context.repo.repo,
-			base: "master",
-			head: branch,
-			title: `Update snapshots for ${muiBranch}`,
-			body: isPr
-				? `changes of https://github.com/mui-org/material-ui/pull/${prNumber}`
-				: "changes on `master`",
-			maintainer_can_modify: true,
-		});
+		try {
+			await octokit.pulls.create({
+				owner: github.context.repo.owner,
+				repo: github.context.repo.repo,
+				base: "master",
+				head: branch,
+				title: `Update snapshots for ${muiBranch}`,
+				body: isPr
+					? `changes of https://github.com/mui-org/material-ui/pull/${prNumber}`
+					: "changes on `master`",
+				maintainer_can_modify: true,
+			});
+		} catch (error) {
+			core.warning(`'${JSON.stringify(error, null, 2)}'`);
+		}
 	}
 }
 


### PR DESCRIPTION
The PR is updated by force pushing already. So ignore the errors that signal that the PR already exist.