### PR TITLE
fix: run on `next` deploys

### DIFF
--- a/lib/a11y-snapshot/jestGlobals.js
+++ b/lib/a11y-snapshot/jestGlobals.js
@@ -10,7 +10,9 @@ function read() {
 		return JSON.parse(fs.readFileSync(globalsPath, { encoding: "utf8" }));
 	} catch (error) {
 		return {
-			__HOST__: "https://material-ui.netlify.com",
+			// netlify default branch: https://material-ui.netlify.app
+			// GitHub default branch: https://next--material-ui.netlify.app
+			__HOST__: "https://next--material-ui.netlify.app",
 		};
 	}
 }


### PR DESCRIPTION
Main development happens on `next` now.