### PR TITLE
fix: Update snapshots for `next`

### DIFF
--- a/lib/a11y-snapshot/__snapshots__/material-ui.test.js.snap
+++ b/lib/a11y-snapshot/__snapshots__/material-ui.test.js.snap
@@ -286,14 +286,14 @@ exports[`chromium / 1`] = `
     </list>
     <paragraph>
       <text>Currently</text>
-      <link>v5.0.0-alpha.3. View versions page.</link>
+      <link>v5.0.0-alpha.4. View versions page.</link>
       <text>. Released under the</text>
       <link>MIT License</link>
       <text>.Copyright ©2020Material-UI.</text>
     </paragraph>
   </contentinfo>
   <link>Material-UI</link>
-  <link>v5.0.0-alpha.3</link>
+  <link>v5.0.0-alpha.4</link>
   <separator orientation="horizontal"></separator>
   <text>Diamond Sponsors</text>
   <link>
@@ -17080,7 +17080,7 @@ exports[`firefox / 1`] = `
     </list>
     <paragraph>
       <text>Currently</text>
-      <link>v5.0.0-alpha.3. View versions page.</link>
+      <link>v5.0.0-alpha.4. View versions page.</link>
       <text>. Released under the</text>
       <link>MIT License</link>
       <text>. Copyright © 2020 Material-UI.</text>


### PR DESCRIPTION
Closes #585 