### PR TITLE
fix: Update audited pages with latest v5 state

### DIFF
--- a/bin/entrypoint.js
+++ b/bin/entrypoint.js
@@ -14,7 +14,7 @@ require("yargs")
 			});
 		},
 		handler: (argv) => {
-			lighthouseAudit({ prNumber: +argv["pr-number"] });
+			return lighthouseAudit({ prNumber: +argv["pr-number"] });
 		},
 	})
 	.command({

--- a/lib/lighthouse-audit.js
+++ b/lib/lighthouse-audit.js
@@ -51,7 +51,7 @@ const pages = [
 	"/components/box",
 	"/components/container",
 	"/components/grid",
-	"/components/grid-list",
+	"/components/image-list",
 	// Inputs
 	"/components/autocomplete",
 	"/components/buttons",
@@ -74,7 +74,7 @@ const pages = [
 	"/components/app-bar",
 	"/components/paper",
 	"/components/cards",
-	"/components/expansion-panels",
+	"/components/accordion",
 	// Feedback
 	"/components/progress",
 	"/components/dialogs",
@@ -124,7 +124,9 @@ async function lighthouseAudit(options) {
 	for (const chunk of chunks) {
 		const auditedChunk = await Promise.all(
 			chunk.map((page) => {
-				return auditPage(lighthouseUrl, page);
+				return auditPage(lighthouseUrl, page).catch((error) => {
+					throw new Error(`Auditing '${page}':\n${error}`);
+				});
 			})
 		);
 


### PR DESCRIPTION
Updates some 301s and 404s (which will be 301s after https://github.com/mui-org/material-ui/pull/23456 is deployed).