### PR TITLE
Wait for demo toolbars to be loaded

### DIFF
--- a/lib/a11y-snapshot/material-ui.test.js
+++ b/lib/a11y-snapshot/material-ui.test.js
@@ -187,9 +187,8 @@ describe.each(["chromium", "firefox"])("%s", (browserType) => {
 });
 
 /**
- *
- * @param {import('playwright').BrowserContext} context
- * @param {*} route
+ * @param {import('playwright').Page} page
+ * @param {string} route
  * @returns {import('playwright').Page}
  */
 async function gotoMuiPage(page, route) {
@@ -197,6 +196,14 @@ async function gotoMuiPage(page, route) {
 	// we wait for a React.lazy component which is mounted in a useEffect
 	// at this point we definitely hydrated
 	await page.waitForSelector("#docsearch-input");
+
+	// demo toolbars are deferred with React.lazy and use a aria-busy skeleton.
+	const lazyElements = await page.$$('[aria-busy="true"]');
+	await page.waitForFunction((elements) => {
+		return elements.map((element) => {
+			return element.getAttribute("aria-busy") !== "true";
+		});
+	}, lazyElements);
 	return page;
 }
 


### PR DESCRIPTION
Updates a11y-snapshot to re-stabilize snapshots after https://github.com/mui-org/material-ui/pull/23108

Demo toolbars are deferred with React.lazy and use a aria-busy skeleton. 