### PR TITLE
More robust waiting for toolbars

### DIFF
--- a/lib/a11y-snapshot/material-ui.test.js
+++ b/lib/a11y-snapshot/material-ui.test.js
@@ -197,13 +197,24 @@ async function gotoMuiPage(page, route) {
 	// at this point we definitely hydrated
 	await page.waitForSelector("#docsearch-input");
 
+	console.log(
+		"waiting for %d lazy elements",
+		(await page.$$("[aria-busy]")).length
+	);
 	// demo toolbars are deferred with React.lazy and use a aria-busy skeleton.
-	const lazyElements = await page.$$('[aria-busy="true"]');
-	await page.waitForFunction((elements) => {
-		return elements.map((element) => {
-			return element.getAttribute("aria-busy") !== "true";
-		});
-	}, lazyElements);
+	await page.waitForFunction(() => {
+		// eslint-disable-next-line no-undef -- document function
+		return document.querySelector('[aria-busy="true"]') === null;
+	});
+	// If the above, generic approach doesn't work try an approach tailored to our toolbars:
+	// await page.waitForSelector('[role="toolbar"][aria-label="demo source"] *', {
+	// 	state: "attached",
+	// });
+	console.log(
+		"%d lazy elements remaining",
+		(await page.$$("[aria-busy]")).length
+	);
+
 	return page;
 }
 


### PR DESCRIPTION
Still getting snapshots with empty toolbars. Probably because we remount `[role="toolbar"]` between fallback states and the loaded state.