### PR TITLE
test: Speed-up CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,8 +29,8 @@ steps:
       restoreKeys: |
         yarn | "$(Agent.OS)"
         yarn
-      path: node_modules
-    displayName: Cache node_modules
+      path: $(Pipeline.Workspace)/.yarn
+    displayName: Cache Yarn packages
 
   - script: |
       yarn install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,10 +25,10 @@ steps:
 
   - task: Cache@2
     inputs:
-      key: 'yarn | v2 | "$(Agent.OS)" | yarn.lock'
+      key: 'yarn-v2 | "$(Agent.OS)" | yarn.lock'
       restoreKeys: |
-        yarn | "$(Agent.OS)"
-        yarn
+        yarn-v2 | "$(Agent.OS)"
+        yarn-v2
       path: $(Pipeline.Workspace)/.yarn
     displayName: Cache Yarn packages
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,8 @@ pool:
 
 variables:
   NVDA_LOG_FILE_PATH: '$(Build.SourcesDirectory)\lib\a11y-snapshot\nvda.log'
-  PLAYWRIGHT_CACHE_FOLDER: ~/.cache/ms-playwright
-  YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+  PLAYWRIGHT_CACHE_FOLDER: %USERPROFILE%\AppData\Local\ms-playwright
+  YARN_CACHE_FOLDER: $(Pipeline.Workspace)\.yarn
 
 steps:
   - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ steps:
 
   - task: Cache@2
     inputs:
-      key: 'yarn | "$(Agent.OS)" | yarn.lock'
+      key: 'yarn | v2 | "$(Agent.OS)" | yarn.lock'
       restoreKeys: |
         yarn | "$(Agent.OS)"
         yarn

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ pool:
 
 variables:
   NVDA_LOG_FILE_PATH: '$(Build.SourcesDirectory)\lib\a11y-snapshot\nvda.log'
+  PLAYWRIGHT_CACHE_FOLDER: ~/.cache/ms-playwright
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
 
 steps:
@@ -32,6 +33,14 @@ steps:
         yarn-v2
       path: $(YARN_CACHE_FOLDER)
     displayName: Cache Yarn packages
+
+  - task: Cache@2
+    inputs:
+      key: 'playwright | "$(Agent.OS)" | yarn.lock'
+      restoreKeys: |
+        playwright | "$(Agent.OS)"
+      path: $(PLAYWRIGHT_CACHE_FOLDER)
+    displayName: Cache Playwright browser binaries
 
   - script: |
       yarn install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ pool:
 
 variables:
   NVDA_LOG_FILE_PATH: '$(Build.SourcesDirectory)\lib\a11y-snapshot\nvda.log'
-  PLAYWRIGHT_CACHE_FOLDER: '%USERPROFILE%\AppData\Local\ms-playwright'
+  PLAYWRIGHT_CACHE_FOLDER: '$(UserProfile)\AppData\Local\ms-playwright'
   YARN_CACHE_FOLDER: '$(Pipeline.Workspace)\.yarn'
 
 steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,8 @@ pool:
 
 variables:
   NVDA_LOG_FILE_PATH: '$(Build.SourcesDirectory)\lib\a11y-snapshot\nvda.log'
-  PLAYWRIGHT_CACHE_FOLDER: %USERPROFILE%\AppData\Local\ms-playwright
-  YARN_CACHE_FOLDER: $(Pipeline.Workspace)\.yarn
+  PLAYWRIGHT_CACHE_FOLDER: '%USERPROFILE%\AppData\Local\ms-playwright'
+  YARN_CACHE_FOLDER: '$(Pipeline.Workspace)\.yarn'
 
 steps:
   - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ pool:
 
 variables:
   NVDA_LOG_FILE_PATH: '$(Build.SourcesDirectory)\lib\a11y-snapshot\nvda.log'
+  YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
 
 steps:
   - powershell: |
@@ -29,7 +30,7 @@ steps:
       restoreKeys: |
         yarn-v2 | "$(Agent.OS)"
         yarn-v2
-      path: $(Pipeline.Workspace)/.yarn
+      path: $(YARN_CACHE_FOLDER)
     displayName: Cache Yarn packages
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,15 @@ steps:
       versionSpec: "12.x"
     displayName: "Install Node.js"
 
+  - task: Cache@2
+    inputs:
+      key: 'yarn | "$(Agent.OS)" | yarn.lock'
+      restoreKeys: |
+        yarn | "$(Agent.OS)"
+        yarn
+      path: node_modules
+    displayName: Cache node_modules
+
   - script: |
       yarn install
     displayName: "install dependencies"
@@ -52,10 +61,3 @@ steps:
   - publish: ${{ variables.NVDA_LOG_FILE_PATH }}
     artifact: nvda.log
     condition: always()
-
-  - task: Npm@1
-    continueOnError: "true"
-    inputs:
-      command: publish
-      publishEndpoint: github
-    displayName: "publish if version changed"


### PR DESCRIPTION
1. Cache n_m 
   Not using yarn cache path since binary building would not be cached which is the slowest task.
   Cache miss: https://dev.azure.com/silbermannsebastian/material-ui-scripts/_build/results?buildId=7471&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9
   Cache hit: https://dev.azure.com/silbermannsebastian/material-ui-scripts/_build/results?buildId=7470&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9
1. Remove unused publish-on-change feature