### PR TITLE
fix: use jest-circus

### DIFF
--- a/lib/a11y-snapshot/jest.config.js
+++ b/lib/a11y-snapshot/jest.config.js
@@ -9,5 +9,10 @@ module.exports = {
 	snapshotSerializers: [require.resolve("./a11y-tree-serializer")],
 	setupFilesAfterEnv: ["./jest.setup.js"],
 	testRegex: "\\.test\\.js$",
+	// With the default runner:
+	// - snapshots spill over into another tests
+	// - beforeEach starts before afterEach in the same context finishes
+	// Using workaround described in https://github.com/facebook/jest/issues/9527#issuecomment-776271802
+	testRunner: "jest-circus/runner",
 	testTimeout: 20000,
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"fs-extra": "^9.1.0",
 		"ink": "^2.7.1",
 		"jest": "^26.6.3",
+		"jest-circus": "^26.6.3",
 		"lighthouse": "^7.0.0",
 		"lodash": "^4.17.20",
 		"netlify": "^6.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2532,6 +2532,11 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -4086,6 +4091,33 @@ jest-changed-files@^26.6.2:
   dependencies:
     "@jest/types" "^26.6.2"
     execa "^4.0.0"
+    throat "^5.0.0"
+
+jest-circus@^26.6.3:
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-26.6.3.tgz#3cc7ef2a6a3787e5d7bfbe2c72d83262154053e7"
+  integrity sha512-ACrpWZGcQMpbv13XbzRzpytEJlilP/Su0JtNCi5r/xLpOUhnaIJr8leYYpLEMgPFURZISEHrnnpmB54Q/UziPw==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^26.6.2"
+    "@jest/test-result" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    "@types/babel__traverse" "^7.0.4"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    co "^4.6.0"
+    dedent "^0.7.0"
+    expect "^26.6.2"
+    is-generator-fn "^2.0.0"
+    jest-each "^26.6.2"
+    jest-matcher-utils "^26.6.2"
+    jest-message-util "^26.6.2"
+    jest-runner "^26.6.3"
+    jest-runtime "^26.6.3"
+    jest-snapshot "^26.6.2"
+    jest-util "^26.6.2"
+    pretty-format "^26.6.2"
+    stack-utils "^2.0.2"
     throat "^5.0.0"
 
 jest-cli@^26.6.3:


### PR DESCRIPTION
With the default runner:
- snapshots spill over into another tests
- beforeEach starts before afterEach in the same context finishes

Using workaround described in https://github.com/facebook/jest/issues/9527#issuecomment-776271802