### PR TITLE
fix: Ignore windows specific v8 exit codes

### DIFF
--- a/lib/a11y-snapshot/index.js
+++ b/lib/a11y-snapshot/index.js
@@ -29,7 +29,10 @@ function a11ySnapshot(options) {
 			{ env: process.env, stdio: "inherit" }
 		);
 		jestProcess.once("exit", (code) => {
-			if (code !== 0) {
+			// https://github.com/sass/node-sass/issues/1283#issuecomment-169450661
+			const ignoredErrorCodes =
+				os.platform() === "win32" ? new Set([3221225477]) : new Set();
+			if (code !== 0 && !ignoredErrorCodes.has(code)) {
 				reject(`Jest failed with exit code '${code}'.`);
 			} else {
 				resolve();


### PR DESCRIPTION
Some runs (e.g. https://github.com/eps1lon/mui-scripts-incubator/runs/2872255333?check_suite_focus=true) pass all tests but jest still exits with non-zero (3221225477) on windows.

Suspicion: `--detect-open-handles` finds an open handle, exits and triggers v8's access violation in windows.