### PR TITLE
fix: Ignore netlify drawer

### DIFF
--- a/lib/a11y-snapshot/a11y-tree-serializer.js
+++ b/lib/a11y-snapshot/a11y-tree-serializer.js
@@ -43,6 +43,7 @@ function serializeAxNode(node) {
 			"combobox list": "MenuListPopup", // what chromium uses
 			"combobox option": "menuitem", // what chromium uses
 			"date editor": "DateTime", // what chromium uses
+			Iframe: "iframe", // what chromium uses
 			"internal frame": "iframe", // not reproducible in chromium
 			"list item marker": "ListMarker", // what chromium uses
 			// Chromium still uses textbox.

--- a/lib/a11y-snapshot/aom.test.js
+++ b/lib/a11y-snapshot/aom.test.js
@@ -246,6 +246,13 @@ function squashTextNodes(children) {
 function pruneA11yTree(node, options) {
 	const { makeStableNode } = options;
 
+	// Ignore netlify drawer which is not rendered on branch deploys.
+	// Since we check in the snapshot of branch deploys but use PR deploys for diffing we always get a diff.
+	// In other words: We remove any different that is expected between branch and PR deploys.
+	if (node.role.toLowerCase() === "iframe" && node.name === "Netlify Drawer") {
+		return undefined;
+	}
+
 	const children = makeStableChildren(
 		squashTextNodes(pruneChildren(node.children))
 	);


### PR DESCRIPTION
Can only hide the drawer with permalinks not deploy previews (https://docs.netlify.com/site-deploys/deploy-previews/).